### PR TITLE
bring in gdt-1.3.0

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -453,7 +453,6 @@ func (a *assertions) jsonOK() bool {
 		}
 		ja := gdtjson.New(exp.JSON, b)
 		if !ja.OK() {
-			a.terminal = ja.Terminal()
 			for _, f := range ja.Failures() {
 				a.Fail(f)
 			}

--- a/eval.go
+++ b/eval.go
@@ -117,12 +117,11 @@ func (s *Spec) get(
 			a = s.doGet(ctx, t, c, res, name, s.Namespace())
 		}
 		success := a.OK()
-		term := a.Terminal()
 		debug.Println(
-			ctx, t, "%s (try %d after %s) ok: %v, terminal: %v",
-			s.Title(), attempts, after, success, term,
+			ctx, t, "%s (try %d after %s) ok: %v",
+			s.Title(), attempts, after, success,
 		)
-		if success || term {
+		if success {
 			ticker.Stop()
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/gdt-dev/gdt v1.2.1
+	github.com/gdt-dev/gdt v1.3.0
 	github.com/samber/lo v1.38.1
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
-github.com/gdt-dev/gdt v1.2.1 h1:tNIpBPLatk8Rb0YFSK+FOzKIhHPYgmLpXQL8qottNcI=
-github.com/gdt-dev/gdt v1.2.1/go.mod h1:StnyGjC/67u59La2u6fh3HwW9MmodVhKdXcLlkgvNSY=
+github.com/gdt-dev/gdt v1.3.0 h1:uUKOdNcXsc399lBQ3ELUarTWqqZBRWhwgXq2J35ocR4=
+github.com/gdt-dev/gdt v1.3.0/go.mod h1:StnyGjC/67u59La2u6fh3HwW9MmodVhKdXcLlkgvNSY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
Gets gdt-dev/kube up to date with gdt@1.3.0, resolving the removed
Assertions.Terminal() method.

Fixes #4 