### PR TITLE
fix failure evaluation

### DIFF
--- a/.github/workflows/gate-tests.yml
+++ b/.github/workflows/gate-tests.yml
@@ -13,7 +13,7 @@ jobs:
   test-skip-kind:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go: ['1.19', '1.20', '1.21']
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,10 +24,15 @@ jobs:
          disable-sudo: true
          allowed-endpoints: >
            github.com:443
+           api.github.com:443
+           proxy.github.com:443
+           raw.githubusercontent.com:443
+           objects.githubusercontent.com:443
+           proxy.golang.org:443
      - name: checkout code
        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
      - name: setup go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
        with:
          go-version: ${{ matrix.go }}
      - name: run non-Kind tests
@@ -37,7 +42,7 @@ jobs:
   test-all:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go: ['1.19', '1.20', '1.21']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -46,10 +51,17 @@ jobs:
        with:
          egress-policy: audit
          disable-sudo: false
+         allowed-endpoints: >
+           github.com:443
+           api.github.com:443
+           proxy.github.com:443
+           raw.githubusercontent.com:443
+           objects.githubusercontent.com:443
+           proxy.golang.org:443
      - name: checkout code
        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
      - name: setup go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+       uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
        with:
          go-version: ${{ matrix.go }}
      - name: create KinD cluster

--- a/assertions.go
+++ b/assertions.go
@@ -340,7 +340,7 @@ func (a *assertions) notFoundOK() bool {
 // lenOK returns true if the subject matches the Len condition, false otherwise
 func (a *assertions) lenOK() bool {
 	exp := a.exp
-	if exp.Len != nil {
+	if exp.Len != nil && a.hasSubject() {
 		// if the supplied resp is a list of objects returned by the dynamic
 		// client check its length
 		list, ok := a.r.(*unstructured.UnstructuredList)


### PR DESCRIPTION
There were two problems with gdt-kube's evaluation. First, I was improperly passing a `*interface{}` instead of a `interface{}` to the `newAssertions()` constructor. This mean the type-casting within methods like `assertions.lenOK()` was failing.

Secondly, I was not calling `t.Error()` appropriately when there were failures collected from the assertions.