### PR TITLE
add ability to pass a KinD config to fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,48 @@ tests:
  - kube.get: pods/nginx
 ```
 
+#### Passing a KinD configuration
+
+You may want to pass a custom KinD configuration resource by using the
+`fixtures.kind.WithConfigPath()` modifier:
+
+
+```go
+import (
+    "github.com/gdt-dev/gdt"
+    gdtkube "github.com/gdt-dev/kube"
+    gdtkind "github.com/gdt-dev/kube/fixtures/kind"
+)
+
+func TestExample(t *testing.T) {
+    s, err := gdt.From("path/to/test.yaml")
+    if err != nil {
+        t.Fatalf("failed to load tests: %s", err)
+    }
+
+    configPath := filepath.Join("testdata", "my-kind-config.yaml")
+
+    ctx := context.Background()
+    ctx = gdt.RegisterFixture(
+        ctx, "kind", gdtkind.New(),
+        gdtkind.WithConfigPath(configPath),
+    )
+    err = s.Run(ctx, t)
+    if err != nil {
+        t.Fatalf("failed to run tests: %s", err)
+    }
+}
+```
+
+In your test file, you would list the "kind" fixture in the `fixtures` list:
+
+```yaml
+name: example-using-kind
+fixtures:
+ - kind
+tests:
+ - kube.get: pods/nginx
+```
 ## Contributing and acknowledgements
 
 `gdt` was inspired by [Gabbi](https://github.com/cdent/gabbi), the excellent

--- a/action.go
+++ b/action.go
@@ -162,7 +162,12 @@ func (a *Action) doList(
 		// We already validated the label selector during parse-time
 		opts.LabelSelector = labels.Set(withlabels).String()
 	}
-	return c.client.Resource(res).Namespace(ns).List(
+	if c.resourceNamespaced(res) {
+		return c.client.Resource(res).Namespace(ns).List(
+			ctx, opts,
+		)
+	}
+	return c.client.Resource(res).List(
 		ctx, opts,
 	)
 }
@@ -176,7 +181,14 @@ func (a *Action) doGet(
 	ns string,
 	name string,
 ) (*unstructured.Unstructured, error) {
-	return c.client.Resource(res).Namespace(ns).Get(
+	if c.resourceNamespaced(res) {
+		return c.client.Resource(res).Namespace(ns).Get(
+			ctx,
+			name,
+			metav1.GetOptions{},
+		)
+	}
+	return c.client.Resource(res).Get(
 		ctx,
 		name,
 		metav1.GetOptions{},

--- a/assertions.go
+++ b/assertions.go
@@ -274,15 +274,18 @@ func (a *assertions) errorOK() bool {
 		// that has a 404 ErrStatus.Code in it
 		apierr, ok := a.err.(*apierrors.StatusError)
 		if ok {
-			if !a.expectsNotFound() {
+			if a.expectsNotFound() {
 				if http.StatusNotFound != int(apierr.ErrStatus.Code) {
 					msg := fmt.Sprintf("got status code %d", apierr.ErrStatus.Code)
 					a.Fail(ExpectedNotFound(msg))
 					return false
 				}
+				// "Swallow" the NotFound error since we expected it.
+				a.err = nil
+			} else {
+				a.Fail(apierr)
+				return false
 			}
-			// "Swallow" the NotFound error since we expected it.
-			a.err = nil
 		}
 	}
 	if exp.Error != "" && a.r != nil {

--- a/connect.go
+++ b/connect.go
@@ -156,6 +156,23 @@ func (c *connection) gvrFromGVK(
 	return r.Resource, nil
 }
 
+// resourceNamespaces returns true if the supplied schema.GroupVersionResource
+// is namespaced, false otherwise
+func (c *connection) resourceNamespaced(gvr schema.GroupVersionResource) bool {
+	apiResources, err := c.disco.ServerResourcesForGroupVersion(
+		gvr.GroupVersion().String(),
+	)
+	if err != nil {
+		panic("expected to find APIResource for GroupVersion " + gvr.GroupVersion().String())
+	}
+	for _, apiResource := range apiResources.APIResources {
+		if apiResource.Name == gvr.Resource {
+			return apiResource.Namespaced
+		}
+	}
+	panic("expected to find APIResource for GroupVersionResource " + gvr.Resource)
+}
+
 // connect returns a connection with a discovery client and a Kubernetes
 // client-go DynamicClient to use in communicating with the Kubernetes API
 // server configured for this Spec

--- a/fixtures/kind/kind_test.go
+++ b/fixtures/kind/kind_test.go
@@ -1,0 +1,65 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package kind_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gdt-dev/gdt"
+	gdtcontext "github.com/gdt-dev/gdt/context"
+	kindfix "github.com/gdt-dev/kube/fixtures/kind"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSingleControlPlane(t *testing.T) {
+	skipKind(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "default-single-control-plane.yaml")
+
+	s, err := gdt.From(fp)
+	require.Nil(err)
+	require.NotNil(s)
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterFixture(ctx, "kind", kindfix.New())
+
+	err = s.Run(ctx, t)
+	require.Nil(err)
+}
+
+func TestOneControlPlaneOneWorker(t *testing.T) {
+	skipKind(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "one-control-plane-one-worker.yaml")
+
+	s, err := gdt.From(fp)
+	require.Nil(err)
+	require.NotNil(s)
+
+	kindCfgPath := filepath.Join("testdata", "kind-config-one-cp-one-worker.yaml")
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterFixture(
+		ctx, "kind-one-cp-one-worker",
+		kindfix.New(
+			kindfix.WithClusterName("kind-one-cp-one-worker"),
+			kindfix.WithConfigPath(kindCfgPath),
+		),
+	)
+
+	err = s.Run(ctx, t)
+	require.Nil(err)
+}
+
+func skipKind(t *testing.T) {
+	_, found := os.LookupEnv("SKIP_KIND")
+	if found {
+		t.Skipf("skipping KinD-requiring test")
+	}
+}

--- a/fixtures/kind/testdata/default-single-control-plane.yaml
+++ b/fixtures/kind/testdata/default-single-control-plane.yaml
@@ -1,0 +1,17 @@
+name: default-single-control-plane
+description: test default KinD cluster has a single control plane node
+fixtures:
+  - kind
+tests:
+  - name: list-all-nodes
+    kube.get: nodes
+    assert:
+      len: 1
+  - name: single-control-plane-node
+    kube:
+      get:
+        type: nodes
+        labels:
+          node-role.kubernetes.io/control-plane: ""
+    assert:
+      len: 1

--- a/fixtures/kind/testdata/kind-config-one-cp-one-worker.yaml
+++ b/fixtures/kind/testdata/kind-config-one-cp-one-worker.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+  labels:
+    role: worker

--- a/fixtures/kind/testdata/one-control-plane-one-worker.yaml
+++ b/fixtures/kind/testdata/one-control-plane-one-worker.yaml
@@ -1,0 +1,25 @@
+name: one-control-plane-one-worker
+description: test default KinD cluster has one control plane node and one worker
+fixtures:
+  - kind-one-cp-one-worker
+tests:
+  - name: list-all-nodes
+    kube.get: nodes
+    assert:
+      len: 2
+  - name: one-control-plane-node
+    kube:
+      get:
+        type: nodes
+        labels:
+          node-role.kubernetes.io/control-plane: ""
+    assert:
+      len: 1
+  - name: one-worker-node
+    kube:
+      get:
+        type: nodes
+        labels:
+          role: worker
+    assert:
+      len: 1


### PR DESCRIPTION
Adds ability to pass a path to a KinD configuration CR in order to configure a KinD fixture.

Closes Issue #9