### PR TITLE
fix inability to reference same-named Kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/gdt-dev/kube.svg)](https://pkg.go.dev/github.com/gdt-dev/kube)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gdt-dev/kube)](https://goreportcard.com/report/github.com/gdt-dev/kube)
-[![Build Status](https://github.com/gdt-dev/kube/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/gdt-dev/kube/actions)
+[![Build Status](https://github.com/gdt-dev/kube/actions/workflows/gate-tests.yml/badge.svg?branch=main)](https://github.com/gdt-dev/kube/actions)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 <div style="float: left">

--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gdt-dev/gdt/api"
 	"gopkg.in/yaml.v3"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
@@ -181,9 +180,10 @@ func InvalidWithLabels(err error, node *yaml.Node) error {
 	)
 }
 
-// ResourceUnknown returns ErrRuntimeResourceUnknown for a given kind
-func ResourceUnknown(gvk schema.GroupVersionKind) error {
-	return fmt.Errorf("%w: %s", ErrResourceUnknown, gvk)
+// ResourceUnknown returns ErrRuntimeResourceUnknown for a given resource or
+// kind arg string
+func ResourceUnknown(arg string) error {
+	return fmt.Errorf("%w: %s", ErrResourceUnknown, arg)
 }
 
 // ExpectedNotFound returns ErrExpectedNotFound for a given status code or

--- a/eval_test.go
+++ b/eval_test.go
@@ -67,6 +67,23 @@ func TestCreateUnknownResource(t *testing.T) {
 	require.Nil(err)
 }
 
+func TestSameNamedKind(t *testing.T) {
+	testutil.SkipIfNoKind(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "same-named-kind.yaml")
+
+	s, err := gdt.From(fp)
+	require.Nil(err)
+	require.NotNil(s)
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterFixture(ctx, "kind", kindfix.New())
+
+	err = s.Run(ctx, t)
+	require.Nil(err)
+}
+
 func TestDeleteResourceNotFound(t *testing.T) {
 	testutil.SkipIfNoKind(t)
 	require := require.New(t)

--- a/spec.go
+++ b/spec.go
@@ -138,7 +138,7 @@ func probablyFilePath(subject string) bool {
 	if strings.ContainsAny(subject, " :\n\r\t") {
 		return false
 	}
-	return strings.ContainsRune(subject, '.')
+	return strings.HasSuffix(subject, ".yaml") || strings.HasSuffix(subject, ".yml")
 }
 
 func (s *Spec) SetBase(b api.Spec) {

--- a/testdata/same-named-kind.yaml
+++ b/testdata/same-named-kind.yaml
@@ -1,0 +1,94 @@
+name: same-named-kind
+description: test multiple Kinds with different APIVersions
+fixtures:
+ - kind
+tests:
+ - kube:
+     create: |
+       apiVersion: apiextensions.k8s.io/v1
+       kind: CustomResourceDefinition
+       metadata:
+         name: foos.example.com
+       spec:
+         group: example.com
+         versions:
+          - name: v1
+            served: true
+            storage: true
+            schema:
+              openAPIV3Schema:
+                type: object
+                properties:
+                  spec:
+                    type: object
+                    properties:
+                      a:
+                        type: string
+                      b:
+                        type: integer
+         scope: Namespaced
+         names:
+           kind: Foo
+           plural: foos
+           singular: foo
+ - kube:
+     create: |
+       apiVersion: apiextensions.k8s.io/v1
+       kind: CustomResourceDefinition
+       metadata:
+         name: foos.anotherexample.com
+       spec:
+         group: anotherexample.com
+         versions:
+          - name: v1
+            served: true
+            storage: true
+            schema:
+              openAPIV3Schema:
+                type: object
+                properties:
+                  spec:
+                    type: object
+                    properties:
+                      a:
+                        type: string
+                      b:
+                        type: integer
+         scope: Namespaced
+         names:
+           kind: Foo
+           plural: foos
+           singular: foo
+ - kube.get: foos.example.com/nonexisting
+   assert:
+     notfound: true
+ - kube.get: foos.anotherexample.com/nonexisting
+   assert:
+     notfound: true
+ # Kube assumes the first Kind-matching resource type, so this should return a
+ # not found, not an unknown resource
+ - kube.get: foos/nonexisting
+   assert:
+     notfound: true
+ - kube:
+     create: |
+       apiVersion: anotherexample.com/v1
+       kind: Foo
+       metadata:
+         name: fooexample
+       spec:
+         a: example
+         b: 42
+ - kube.get: foos.anotherexample.com/fooexample
+   assert:
+     matches:
+       spec:
+         b: 42
+ - kube.get: foos.v1.anotherexample.com/fooexample
+   assert:
+     matches:
+       spec:
+         b: 42
+ - kube.delete: foos.anotherexample.com/fooexample
+ - kube.delete: crds/foos.example.com
+ - kube.delete: crds/foos.anotherexample.com


### PR DESCRIPTION
There were a couple problems that were the root cause of this issue. First, I was only handling the difference between namespaced and non-namespaced CRDs in the GET action. For CREATE, DELETE, and APPLY, I was not properly differentiating between cluster-scoped and namespace-scoped CRDs.

After fixing that, there was a problem with how the `gvrFromGVK` method on the connection struct was discovering an APIResource from the GroupVersionKind. I was only passing in the Kind instead of the GroupVersion information as well, which resulted in the discovery cache in the kube client failing to match the correct CRD when there were two different CRDs with the same Kind but different GroupVersions.

Closes Issue #21