### PR TITLE
fix bug in var jsonpath selection

### DIFF
--- a/testdata/json.yaml
+++ b/testdata/json.yaml
@@ -25,6 +25,20 @@ tests:
           $.metadata.uid: uuid4
           $.metadata.creationTimestamp: date-time
 
+  - name: deployment-json-assertions-list
+    timeout:
+      after: 20s
+    kube:
+      get:
+        type: deployments
+        labels:
+          app: nginx
+    assert:
+      len: 1
+      json:
+        paths:
+          $[0].spec.replicas: 2
+
   - name: delete-deployment
     kube:
       delete: deployments/nginx

--- a/var.go
+++ b/var.go
@@ -54,7 +54,7 @@ func extractFrom(path string, out any) (any, error) {
 	case *unstructured.Unstructured:
 		normalized = out.Object
 	case *unstructured.UnstructuredList:
-		results := make([]map[string]any, len(out.Items))
+		results := make([]any, len(out.Items))
 		for x, item := range out.Items {
 			results[x] = item.Object
 		}


### PR DESCRIPTION
When looking up a JSONPath in the output of a list operation, one specifies the path like so: `$[0].status.podIP`. However, the way that we were transforming UnstructuredList to any was incorrect and therefore the github.com/theory/jsonpath.Select() function wasn't understanding the provided input. This patch fixes this problem by changing the input from []map[string]any to []any.