### PR TITLE
support `assert.require` to fail test scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ matches some expectation:
   Kubernetes resource returned in a `kubectl get` response.
 * `assert`: (optional) object containing assertions to make about the
   action performed by the test.
+* `assert.require`: (optional) a boolean indicating whether a failed assertion
+  will cause the test scenario's execution to stop. The default behaviour of
+  `gdt` is to continue execution of subsequent test specs in a test scenario when
+  an assertion fails.
 * `assert.error`: (optional) string to match a returned error from the
   Kubernetes API server.
 * `assert.len`: (optional) int with the expected number of items returned.

--- a/assertions.go
+++ b/assertions.go
@@ -21,6 +21,9 @@ import (
 
 // Expect contains one or more assertions about a kube client call
 type Expect struct {
+	// Require indicates that any failed assertion should stop the execution of
+	// the test scenario in which the test spec is contained.
+	Require bool `yaml:"require,omitempty"`
 	// Error is a string that is expected to be returned as an error string
 	// from the client call
 	// TODO(jaypipes): Make this polymorphic to be either a shortcut string

--- a/eval.go
+++ b/eval.go
@@ -54,7 +54,14 @@ func (s *Spec) Eval(ctx context.Context) (*api.Result, error) {
 		}
 		return res, nil
 	}
-	return api.NewResult(api.WithFailures(a.Failures()...)), nil
+	stopOnFail := false
+	if s.Assert != nil {
+		stopOnFail = s.Assert.Require
+	}
+	return api.NewResult(
+		api.WithStopOnFail(stopOnFail),
+		api.WithFailures(a.Failures()...),
+	), nil
 }
 
 // cleanupAutoNamespace returns a cleanup function that deletes the

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/gdt-dev/core v1.10.0
+	github.com/gdt-dev/core v1.10.3
 	github.com/samber/lo v1.51.0
 	github.com/stretchr/testify v1.11.1
 	github.com/theory/jsonpath v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gdt-dev/core v1.10.0 h1:yX0MG2Tt+O34JGDFWcS63LV47lWpizto4HAyR/ugAC0=
-github.com/gdt-dev/core v1.10.0/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
+github.com/gdt-dev/core v1.10.3 h1:4cl8h8/SeL5oBzDFyg7WhZbRcLRBb6SUY57L5Swju2A=
+github.com/gdt-dev/core v1.10.3/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/spec.go
+++ b/spec.go
@@ -75,6 +75,10 @@ type Spec struct {
 	//     having such a label.
 	//   * the string `--all` to delete all resources of that kind.
 	KubeDelete string `yaml:"kube.delete,omitempty"`
+	// Require is an object containing the conditions that the Spec will
+	// assert. If any condition fails, the test scenario execution will stop
+	// and be marked as failed.
+	Require *Expect `yaml:"require,omitempty"`
 	// Assert houses the various assertions to be made about the kube client
 	// call (Create, Apply, Get, etc)
 	// TODO(jaypipes): Make this polymorphic to be either a single assertion


### PR DESCRIPTION
Adds support for the `assert.require` field which contains a boolean value that instructs the gdt scenario to exit with a failure when an assertion fails. This is equivalent to the difference between testify assert and testify require or the Go testing.T.Error versus testing.T.Fatal.

Issue gdt-dev/gdt#66