### PR TITLE
support api.DefaultsHandler

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -32,9 +32,37 @@ type kubeDefaults struct {
 	Namespace string `yaml:"namespace,omitempty"`
 }
 
-// Defaults is the known HTTP plugin defaults collection
+// Defaults is the known kube plugin defaults collection
 type Defaults struct {
 	kubeDefaults
+}
+
+// Merge merges the supplies map of key/value combinations with the set of
+// handled defaults for the plugin. The supplied key/value map will NOT be
+// unpacked from its top-most plugin named element. So, for example, the
+// kube plugin should expect to get a map that looks like
+// "kube:namespace:<namespace>" and not "namespace:<namespace>".
+func (d *Defaults) Merge(vals map[string]any) {
+	kubeValsAny, ok := vals[pluginName]
+	if !ok {
+		return
+	}
+	kubeVals, ok := kubeValsAny.(map[string]string)
+	if !ok {
+		return
+	}
+	cfg, ok := kubeVals["config"]
+	if ok {
+		d.Config = cfg
+	}
+	ctx, ok := kubeVals["context"]
+	if ok {
+		d.Context = ctx
+	}
+	ns, ok := kubeVals["namespace"]
+	if ok {
+		d.Namespace = ns
+	}
 }
 
 func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/gdt-dev/core v1.10.5
+	github.com/gdt-dev/core v1.11.0
 	github.com/samber/lo v1.51.0
 	github.com/stretchr/testify v1.11.1
 	github.com/theory/jsonpath v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gdt-dev/core v1.10.5 h1:plVO6WegOEuJTopnmTRQTIwyvHY2iG4xXDax2OP4fO8=
-github.com/gdt-dev/core v1.10.5/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
+github.com/gdt-dev/core v1.11.0 h1:jEKDMZ8eoQIQMlTB2C6Ai6q7CfgHJ3y9MVFSzdgc208=
+github.com/gdt-dev/core v1.11.0/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/plugin.go
+++ b/plugin.go
@@ -7,7 +7,6 @@ package kube
 import (
 	"github.com/gdt-dev/core/api"
 	gdtplugin "github.com/gdt-dev/core/plugin"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -39,7 +38,7 @@ func (p *plugin) Info() api.PluginInfo {
 	}
 }
 
-func (p *plugin) Defaults() yaml.Unmarshaler {
+func (p *plugin) Defaults() api.DefaultsHandler {
 	return &Defaults{}
 }
 


### PR DESCRIPTION
Updates the kube plugin to implement the new core `api.DefaultsHandler` interface and understand how to merge default values.

Issue gdt-dev/gdt#68