### PR TITLE
support set-based label selectors

### DIFF
--- a/action.go
+++ b/action.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gdt-dev/core/parse"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -169,10 +168,10 @@ func (a *Action) doList(
 	resName := res.Resource
 	labelSelString := ""
 	opts := metav1.ListOptions{}
-	withlabels := a.Get.Labels
-	if withlabels != nil {
+	sel := a.Get.LabelSelector
+	if sel != nil {
 		// We already validated the label selector during parse-time
-		labelsStr := labels.Set(withlabels).String()
+		labelsStr := sel.String()
 		labelSelString = fmt.Sprintf(" (labels: %s)", labelsStr)
 		opts.LabelSelector = labelsStr
 	}
@@ -484,11 +483,11 @@ func (a *Action) doDeleteCollection(
 	ns string,
 ) error {
 	opts := metav1.ListOptions{}
-	withlabels := a.Delete.Labels
 	labelSelString := ""
-	if withlabels != nil {
+	sel := a.Delete.LabelSelector
+	if sel != nil {
 		// We already validated the label selector during parse-time
-		labelsStr := labels.Set(withlabels).String()
+		labelsStr := sel.String()
 		labelSelString = fmt.Sprintf(" (labels: %s)", labelsStr)
 		opts.LabelSelector = labelsStr
 	}

--- a/testdata/parse-label-selector.yaml
+++ b/testdata/parse-label-selector.yaml
@@ -1,0 +1,55 @@
+name: parse-label-selector
+description: a scenario with several well-formed kube/get specs with label selectors
+
+tests:
+
+ - name: label selector, one label only
+   kube:
+     get:
+       type: pod
+       labels:
+         app: nginx
+
+ - name: label selector, multiple labels
+   kube:
+     get:
+       type: pod
+       labels:
+         app: nginx
+         version: 1
+
+ - name: label selector, IN expression
+   kube:
+     get:
+       type: pod
+       labels-in:
+         app:
+           - argorollouts
+           - argo-rollouts
+
+ - name: label selector, NOT IN expression
+   kube:
+     get:
+       type: pod
+       labels-not-in:
+         app:
+           - argorollouts
+           - argo-rollouts
+
+ - name: label selector, AND'ed expression with IN and NOT IN expressions
+   kube:
+     get:
+       type: pod
+       labels-in:
+         app:
+           - argo
+       labels-not-in:
+         app:
+           - argo-rollouts
+           - argorollouts
+
+ - name: label selector, string complex label selector expression 
+   kube:
+     get:
+       type: pod
+       labels: app in (argo),app notin (argo-rollouts,argorollouts)


### PR DESCRIPTION
Adds a flexible label selector functionality to the `gdt-kube` plugin.

When selecting objects from the Kubernetes API, you can use a label selector in the `kube.get` and `kube.delete` test spec actions. This label selector functionality is incredibly flexible. You can use a `kubectl`-style label selector string, like so:

```yaml
 - name: select pods that have the "app=argo" label but do NOT have the "app=argo-rollouts" or "app=argorollouts" label
   kube:
     get:
       type: pod
       labels: app in (argo),app notin (argo-rollouts,argorollouts)
```

The `kube.get.labels` field can also be a map of string to string, which is more aligned with how `gdt`'s YAML syntax is structured. This example selects pods that have **both** the `app=myapp` **and** the `region=myregion` label:

```yaml
 - name: select pods that have BOTH the app=myapp AND region=myregion label
   kube:
     get:
       type: pod
       labels:
         app: myapp
         region: myregion
```

The `kube.get.labels-in` field is a map of string to slice of strings and gets translated into a "label IN (val1, val2)" expression. This example selects pods that have **either** the `app=myapp` label **or** the `app=test` label:

```yaml
 - name: select pods that have EITHER the app=myapp OR app=test label
   kube:
     get:
       type: pod
       labels-in:
         app:
          - myapp
          - test
```

The `kube.get.labels-not-in` field is also a map of string to slice of strings and gets translated into a `label NOTIN (val1, val2)` expression. This example selects pods that **do not** have either the `app=myapp` or the `app=test` label.

```yaml
 - name: select pods that have DON'T HAVE the app=myapp OR app=test label
   kube:
     get:
       type: pod
       labels-not-in:
         app:
          - myapp
          - test
```

You can combine the `kube.get.labels`, `kube.get.labels-in` and `kube.get.labels-not-in` fields to create complex querying expressions. This example selects pods that have the `app=myapp` label **and** have **either** the `category=test` or `category=staging` label **and** do **not** have a `personal=true` label:

```yaml
 - name: select pods that have have an app=myapp label AND have either a category=test or category=staging label AND do not have the personal=true label
   kube:
     get:
       type: pod
       labels:
         app: myapp
       labels-in:
         category:
          - test
          - staging
       labels-not-in:
         personal:
          - true
```

Issue #35